### PR TITLE
Optimized PendingNotification Query

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://notifo.io</PackageProjectUrl>
     <PackageTags>notifo xamarin firebase</PackageTags>
-    <Version>1.2.1-beta1</Version>
+    <Version>1.2.1-beta2</Version>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 </Project>

--- a/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
+++ b/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
@@ -155,6 +155,8 @@ namespace Notifo.SDK.NotifoMobilePush
         private async Task<List<UserNotificationDto>> GetPendingNotifications1_4Async(int take, DateTime after,
             CancellationToken ct)
         {
+            // use DeviceIdentifier because Token could change over time and you could miss pending notifications. DeviceIdentifier should be more stable.
+            // take is not returning the exact amount of entries. It's taking the X last entries, then filters for messages that are unseen.
             var result = await Client.Notifications.GetMyDeviceNotificationsAsync(DeviceIdentifier, after, true, take * 2, ct);
 
             return result.Items;

--- a/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
+++ b/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
@@ -155,7 +155,7 @@ namespace Notifo.SDK.NotifoMobilePush
         private async Task<List<UserNotificationDto>> GetPendingNotifications1_4Async(int take, DateTime after,
             CancellationToken ct)
         {
-            var result = await Client.Notifications.GetMyDeviceNotificationsAsync(DeviceIdentifier, after, true, take, ct);
+            var result = await Client.Notifications.GetMyDeviceNotificationsAsync(DeviceIdentifier, after, true, take * 2, ct);
 
             return result.Items;
         }

--- a/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
+++ b/sdk/Notifo.SDK.Core/NotifoMobilePush/NotifoMobilePushImplementation.ios.cs
@@ -155,7 +155,7 @@ namespace Notifo.SDK.NotifoMobilePush
         private async Task<List<UserNotificationDto>> GetPendingNotifications1_4Async(int take, DateTime after,
             CancellationToken ct)
         {
-            var result = await Client.Notifications.GetMyDeviceNotificationsAsync(token, after, true, take * 2, ct);
+            var result = await Client.Notifications.GetMyDeviceNotificationsAsync(DeviceIdentifier, after, true, take, ct);
 
             return result.Items;
         }


### PR DESCRIPTION
Changed the query parameter from Token to DeviceIdentifier.
Token can change over time and so it could be possible that notifications wouldn't be downloaded if you're offline and your token changes in meantime. Same when you logout and login again.