### PR TITLE
Fix/completed collection error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://notifo.io</PackageProjectUrl>
     <PackageTags>notifo xamarin firebase</PackageTags>
-    <Version>1.2.1-beta3</Version>
+    <Version>1.2.1-beta4</Version>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 </Project>

--- a/sdk/Notifo.SDK.Core/CommandQueue/DefaultCommandQueue.cs
+++ b/sdk/Notifo.SDK.Core/CommandQueue/DefaultCommandQueue.cs
@@ -46,8 +46,6 @@ namespace Notifo.SDK.CommandQueue
         public async Task CompleteAsync(
             CancellationToken ct)
         {
-            queue.CompleteAdding();
-
             Trigger();
 
             foreach (var trigger in commandTriggers.OfType<IDisposable>())


### PR DESCRIPTION
… additions". by removing "queue.CompleteAdding();" from completeAsync for logout.

This issue happened if user logged out and directly logged back in again without closing the app first. If we mark the collection as "completed" we cannot add the command to register.

I tested it locally with our app. Login -> Logout -> login worked without any issues. Token got updated